### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ About mkdocs
 
 Home: http://www.mkdocs.org
 
-Package license: BSD-2-Clause
+Package license: BSD 2-Clause
 
 Feedstock license: BSD 3-Clause
 
-Summary: Project documentation with Markdown
+Summary: Project documentation with Markdown.
 
 
 
@@ -31,7 +31,6 @@ It is possible to list all of the versions of `mkdocs` available on your platfor
 ```
 conda search mkdocs --channel conda-forge
 ```
-
 
 
 About conda-forge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
@@ -14,6 +12,8 @@ environment:
   # We set a default Python version for the miniconda that is to be installed. This can be
   # overridden in the matrix definition where appropriate.
   CONDA_PY: "27"
+  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +21,27 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +62,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,56 +1,56 @@
-{% set version = "0.15.3" %}
+{% set version = "0.16.0" %}
 
 package:
-    name: mkdocs
-    version: {{ version }}
+  name: mkdocs
+  version: {{ version }}
 
 source:
-    fn: mkdocs-{{ version }}.tar.gz
-    url: https://pypi.python.org/packages/source/m/mkdocs/mkdocs-{{ version }}.tar.gz
-    md5: 389e268822ecee2af5f5c0b00d89fb4a
+  fn: mkdocs-{{ version }}.tar.gz
+  url: https://github.com/mkdocs/mkdocs/archive/{{ version }}.tar.gz
+  sha256: ff0108563ce8a33f4a0bc1f99e9817bd5cab2c9532f8a5ff272beba864066381
 
 build:
-    number: 0
-    script: python setup.py install --single-version-externally-managed --record record.txt
-    preserve_egg_dir: True
-    entry_points:
-        - mkdocs = mkdocs.__main__:cli
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  preserve_egg_dir: True
+  entry_points:
+    - mkdocs = mkdocs.__main__:cli
 
 requirements:
-    build:
-        - python
-        - setuptools
-    run:
-        - python
-        - click >=3.3
-        - jinja2 >=2.7.1
-        - livereload >=2.3.2
-        - markdown >=2.3.1
-        - mkdocs-bootstrap >=0.1.1
-        - mkdocs-bootswatch >=0.1.0
-        - pyyaml >=3.10
-        - tornado >=4.1
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - click >=3.3
+    - jinja2 >=2.7.1
+    - livereload >=2.3.2
+    - markdown >=2.3.1
+    - mkdocs-bootstrap >=0.1.1
+    - mkdocs-bootswatch >=0.1.0
+    - pyyaml >=3.10
+    - tornado >=4.1
 
 test:
-    imports:
-        - mkdocs
-        - mkdocs.commands
-        - mkdocs.config
-        - mkdocs.tests
-        - mkdocs.tests.config
-        - mkdocs.tests.utils
-        - mkdocs.themes
-        - mkdocs.themes.mkdocs
-        - mkdocs.themes.readthedocs
-        - mkdocs.utils
-    commands:
-        - mkdocs --help
+  imports:
+    - mkdocs
+    - mkdocs.commands
+    - mkdocs.config
+    - mkdocs.tests
+    - mkdocs.tests.config
+    - mkdocs.tests.utils
+    - mkdocs.themes
+    - mkdocs.themes.mkdocs
+    - mkdocs.themes.readthedocs
+    - mkdocs.utils
+  commands:
+    - mkdocs --help
 
 about:
-    home: http://www.mkdocs.org
-    license: BSD-2-Clause
-    summary: Project documentation with Markdown
+  home: http://www.mkdocs.org
+  license: BSD 2-Clause
+  summary: 'Project documentation with Markdown.'
 
 extra:
-    recipe-maintainers:
-        - ocefpaf
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
## Version 0.16 (2016-11-04)

### Major Additions to Version 0.16.0

#### Template variables refactored. (\#874)

##### Page Context

Page specific variable names in the template context have been refactored as
defined in [Custom Themes](../user-guide/custom-themes/#page). The
old variable names will issue a warning but continue to work for version 0.16,
but may be removed in a future version.

Any of the following old page variables should be updated to the new ones in
user created and third-party templates:

| Old Variable Name | New Variable Name   |
| ----------------- | ------------------- |
| current_page      | [page]              |
| page_title        | [page.title]        |
| content           | [page.content]      |
| toc               | [page.toc]          |
| meta              | [page.meta]         |
| canonical_url     | [page.canonical_url]|
| previous_page     | [page.previous_page]|
| next_page         | [page.next_page]    |

[page]: ../user-guide/custom-themes/#page
[page.title]: ../user-guide/custom-themes/#pagetitle
[page.content]: ../user-guide/custom-themes/#pagecontent
[page.toc]: ../user-guide/custom-themes/#pagetoc
[page.meta]: ../user-guide/custom-themes/#pagemeta
[page.canonical_url]: ../user-guide/custom-themes/#pagecanonical_url
[page.previous_page]: ../user-guide/custom-themes/#pageprevious_page
[page.next_page]: ../user-guide/custom-themes/#pagenext_page

##### Global Context

Additionally, a number of global variables have been altered and/or deprecated
and user created and third-party templates should be updated as outlined below:

Previously, the global variable `include_nav` was altered programmatically based
on the number of pages in the nav. The variable will issue a warning but
continue to work for version 0.16, but may be removed in a future version. Use
`{% if nav|length>1 %}` instead.

Previously, the global variable `include_next_prev` was altered programmatically
based on the number of pages in the nav. The variable will issue a warning but
continue to work for version 0.16, but may be removed in a future version. Use
`{% if page.next_page or page.previous_page %}` instead.

Previously the global variable `page_description` was altered programmatically
based on whether the current page was the homepage. Now it simply maps to
`config['site_description']`. Use `{% if page.is_homepage %}` in the template to
conditionally change the description.

The global variable `homepage_url` maps directly to `nav.homepage.url` and is
being deprecated. The variable will issue a warning but continue to work for
version 0.16, but may be removed in a future version. Use `nav.homepage.url`
instead.

The global variable `favicon` maps to the configuration setting `site_favicon`.
Both the template variable and the configuration setting are being deprecated
and will issue a warning but continue to work for version 0.16, and may be
removed in a future version. Use `{{ base_url }}/img/favicon.ico` in your
template instead. Users can simply save a copy of their custom favicon icon to
`img/favicon.ico` in either their `docs_dir` or `theme_dir`.

A number of variables map directly to similarly named variables in the `config`.
Those variables are being deprecated and will issue a warning but continue to
work for version 0.16, but may be removed in a future version. Use
`config.var_name` instead, where `var_name` is the name of one of the
[configuration] variables.

[configuration]: /user-guide/configuration.md

Below is a summary of all of the changes made to the global context:

| Old Variable Name | New Variable Name or Expression        |
| ----------------- | -------------------------------------- |
| current_page      | page                                   |
| include_nav       | nav&#124;length&gt;1                   |
| include_next_prev | (page.next_page or page.previous_page) |
| site_name         | config.site_name                       |
| site_author       | config.site_author                     |
| page_description  | config.site_description                |
| repo_url          | config.repo_url                        |
| repo_name         | config.repo_name                       |
| site_url          | config.site_url                        |
| copyright         | config.copyright                       |
| google_analytics  | config.google_analytics                |
| homepage_url      | nav.homepage.url                       |
| favicon           | {{ base_url }}/img/favicon.ico         |

#### Increased Template Customization. (\#607)

The built-in themes have been updated by having each of their many parts wrapped
in template blocks which allow each individual block to be easily overridden
using the `theme_dir` config setting. Without any new settings, you can use a
different analytics service, replace the default search function, or alter the
behavior of the navigation, among other things. See the relevant
[documentation][blocks] for more details.

To enable this feature, the primary entry point for page templates has been
changed from `base.html` to `main.html`. This allows `base.html` to continue to
exist while allowing users to override `main.html` and extend `base.html`. For
version 0.16, `base.html` will continue to work if no `main.html` template
exists, but it is deprecated and will raise a warning. In version 1.0, a build
will fail if no `main.html` template exists. Any custom and third party
templates should be updated accordingly.

The easiest way for a third party theme to be updated would be to simply add a
`main.html` file which only contains the following line:

```django
{% extends "base.html" %}
```

That way, the theme contains the `main.html` entry point, and also supports
overriding blocks in the same manner as the built-in themes. Third party themes
are encouraged to wrap the various pieces of their templates in blocks in order
to support such customization.

[blocks]: ../user-guide/styling-your-docs/#overriding-template-blocks

#### Auto-Populated `extra_css` and `extra_javascript` Deprecated. (\#986)

In previous versions of MkDocs, if the `extra_css` or `extra_javascript` config
settings were empty, MkDocs would scan the `docs_dir` and auto-populate each
setting with all of the CSS and JavaScript files found. This behavior is
deprecated and a warning will be issued. In the next release, the auto-populate
feature will stop working and any unlisted CSS and JavaScript files will not be
included in the HTML templates. In other words, they will still be copied to the
`site-dir`, but they will not have any effect on the theme if they are not
explicitly listed.

All CSS and javaScript files in the `docs_dir` should be explicitly listed in
the `extra_css` or `extra_javascript` config settings going forward.

#### Support for dirty builds. (\#990)

For large sites the build time required to create the pages can become problematic,
thus a "dirty" build mode was created. This mode simply compares the modified time
of the generated HTML and source markdown. If the markdown has changed since the
HTML then the page is re-constructed. Otherwise, the page remains as is. This mode
may be invoked in both the `mkdocs serve` and `mkdocs build` commands:

```text
mkdocs serve --dirtyreload
```

```text
mkdocs build --dirty
```

It is important to note that this method for building the pages is for development
of content only, since the navigation and other links do not get updated on other
pages.

#### Stricter Directory Validation

Previously, a warning was issued if the `site_dir` was a child directory of the
`docs_dir`. This now raises an error. Additionally, an error is now raised if
the `docs_dir` is set to the directory which contains your config file rather
than a child directory. You will need to rearrange you directory structure to
better conform with the documented [layout].

[layout]: ../user-guide/writing-your-docs/#file-layout

### Other Changes and Additions to Version 0.16.0

* Bugfix: Support `gh-deploy` command on Windows with Python 3 (\#722)
* Bugfix: Include .woff2 font files in Python package build (\#894)
* Various updates and improvements to Documentation Home Page/Tutorial (\#870)
* Bugfix: Support livereload for config file changes (\#735)
* Bugfix: Non-media template files are no longer copied with media files (\#807)
* Add a flag (-e/--theme-dir) to specify theme directory with the commands
  `mkdocs build` and `mkdocs serve` (\#832)
* Fixed issues with Unicode file names under Windows and Python 2. (\#833)
* Improved the styling of in-line code in the MkDocs theme. (\#718)
* Bugfix: convert variables to JSON when being passed to JavaScript (\#850)
* Updated the ReadTheDocs theme to match the upstream font sizes and colors
  more closely. (\#857)
* Fixes an issue with permalink markers showing when the mouse was far above
  them (\#843)
* Bugfix: Handle periods in directory name when automatically creating the
  pages config. (\#728)
* Update searching to Lunr 0.7, which comes with some performance enhancements
  for larger documents (\#859)
* Bugfix: Support SOURCE_DATE_EPOCH environment variable for "reproducible"
  builds (\#938)
* Follow links when copying media files (\#869).
* Change "Edit on..." links to point directly to the file in the source
  repository, rather than to the root of the repository (\#975), configurable
  via the new [`edit_uri`](../user-guide/configuration.md#edit_uri) setting.
* Bugfix: Don't override config value for strict mode if not specified on CLI
  (\#738).
* Add a `--force` flag to the `gh-deploy` command to force the push to the
  repository (\#973).
* Improve alignment for current selected menu item in readthedocs theme (\#888).
* `http://user.github.io/repo` => `https://user.github.io/repo/` (\#1029).
* Improve installation instructions (\#1028).
* Account for wide tables and consistently wrap inline code spans (\#834).
* Bugfix: Use absolute URLs in nav & media links from error templates (\#77).