### PR TITLE
Fix tornado version dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 126e9b871adeb077facccc375066fddae1485c7deebe3f10f2052b9a15514fb9
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
@@ -26,7 +26,7 @@ requirements:
     - livereload >=2.5.1
     - markdown >=2.3.1
     - pyyaml >=3.10
-    - tornado >=4.1
+    - tornado >=4.1,<5.0
 
 test:
   imports:


### PR DESCRIPTION
`mkdocs` does not work with `tornado >=5.0` yet.