### PR TITLE
Fix tornado dependency version for mkdocs 1.0.2 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 91ba1d518fb29e7175e48d5a2be9dd775a2355347f86eeb69775abe8da47daf6
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
@@ -26,7 +26,7 @@ requirements:
     - livereload >=2.5.1
     - markdown >=2.3.1
     - pyyaml >=3.10
-    - tornado >=4.1,<5.0
+    - tornado >=5.0
 
 test:
   imports:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# create minimal mkdocs project
+mkdir -p /tmp/test_mkdocs_build/docs
+cat <<'EOT' > /tmp/test_mkdocs_build/docs/index.md
+# Just a Test
+just a test..
+EOT
+cat <<'EOT' > /tmp/test_mkdocs_build/mkdocs.yml
+site_name: mkdocs
+pages:
+- 'Home': 'index.md'
+EOT
+
+# build it..
+cd /tmp/test_mkdocs_build/
+mkdocs build
+
+# on correct execution some files should have been created and we can check the
+# headline we created..
+grep '<h1 id="just-a-test">Just a Test</h1>' site/index.html


### PR DESCRIPTION
Was probably overlooked during adapting dep versions.. compare upstream deps for mkdocs 1.0.2: https://github.com/mkdocs/mkdocs/blob/954b4cb0da9b9b38475bd8dfec2f481df902e6e8/setup.py#L58-L64

Right now the conda-forge package for mkdocs v.1.0.2 can not be used IMHO, since it will install a tornado version the package refuses to run with and it is not possible to update tornado, as it refuses to do so because of the wrong dep version specs in the package.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
